### PR TITLE
More QoL improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,17 @@
 {
     "name": "vscode-map-preview",
-    "version": "0.5.7",
+    "version": "0.5.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "0.5.7",
-            "dependencies": {
-                "file-url": "^3.0.0",
-                "node-uuid": "^1.4.8"
-            },
+            "name": "vscode-map-preview",
+            "version": "0.5.9",
             "devDependencies": {
                 "@types/mocha": "^5.2.7",
                 "@types/node": "^13.5.0",
                 "@types/vscode": "^1.38.0",
-                "typescript": "^4.1.3"
+                "typescript": "^5.2.2"
             },
             "engines": {
                 "vscode": "^1.38.0"
@@ -38,33 +35,17 @@
             "integrity": "sha512-0NO9qrrEJBO8FsqHCrFMgR2suKnwCsKBWvRSb2OzH5gs4i3QO5AhEMQYrSzDbU/wLPt7N617/rN9lPY213gmwg==",
             "dev": true
         },
-        "node_modules/file-url": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/file-url/-/file-url-3.0.0.tgz",
-            "integrity": "sha512-g872QGsHexznxkIAdK8UiZRe7SkE6kvylShU4Nsj8NvfvZag7S0QuQ4IgvPDkk75HxgjIVDwycFTDAgIiO4nDA==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/node-uuid": {
-            "version": "1.4.8",
-            "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-            "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-            "bin": {
-                "uuid": "bin/uuid"
-            }
-        },
         "node_modules/typescript": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-            "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         }
     },
@@ -87,20 +68,10 @@
             "integrity": "sha512-0NO9qrrEJBO8FsqHCrFMgR2suKnwCsKBWvRSb2OzH5gs4i3QO5AhEMQYrSzDbU/wLPt7N617/rN9lPY213gmwg==",
             "dev": true
         },
-        "file-url": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/file-url/-/file-url-3.0.0.tgz",
-            "integrity": "sha512-g872QGsHexznxkIAdK8UiZRe7SkE6kvylShU4Nsj8NvfvZag7S0QuQ4IgvPDkk75HxgjIVDwycFTDAgIiO4nDA=="
-        },
-        "node-uuid": {
-            "version": "1.4.8",
-            "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-            "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        },
         "typescript": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-            "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
             "dev": true
         }
     }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
         "onCommand:map.preview-with-proj"
     ],
     "main": "./out/src/extension",
-    "browser": "./out/web/extension.js",
     "contributes": {
         "menus": {
             "editor/title": [

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "onCommand:map.preview-with-proj"
     ],
     "main": "./out/src/extension",
+    "browser": "./out/web/extension.js",
     "contributes": {
         "menus": {
             "editor/title": [
@@ -352,14 +353,11 @@
         "compile": "tsc -p ./",
         "watch": "tsc -w -p ./"
     },
-    "dependencies": {
-        "file-url": "^3.0.0",
-        "node-uuid": "^1.4.8"
-    },
+    "dependencies": {},
     "devDependencies": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^13.5.0",
         "@types/vscode": "^1.38.0",
-        "typescript": "^4.1.3"
+        "typescript": "^5.2.2"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -183,23 +183,7 @@ class PreviewDocumentContentProvider implements vscode.TextDocumentContentProvid
         }
     }
 
-    private cleanText(text: string): string {
-        const scrubRegexes = [
-            { regex: /\\/g, replace: "\\\\" },                      //Existing backslashes
-            { regex: /(<\!\[CDATA\[[\s\S]*?]]>)/g, replace: "" },   //CDATA blocks in XML
-            { regex: /`/g, replace: "\\`" },                        //Backticks
-            { regex: /\${/g, replace: "\\${" }                      //Start of ES6 template string placeholder
-        ];
-        for (const r of scrubRegexes) {
-            text = text.replace(r.regex, r.replace);
-        }
-        return text;
-    }
-
     private createMapPreview(doc: vscode.TextDocument, projection: string = null) {
-        //Should we languageId check here?
-        const text = this.cleanText(doc.getText());
-    
         const config = vscode.workspace.getConfiguration("map.preview");
         /*
         //We cannot proceed if default base layer is one that requires API keys and no API key has been provided

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -274,6 +274,7 @@ function loadWebView(content: PreviewDocumentContentProvider, previewUri: vscode
             // Restrict the webview to only loading content from our extension's `static` directory.
             localResourceRoots: [
                 vscode.Uri.file(path.join(extensionPath, 'static')),
+                // IMPORTANT: Otherwise our generated HTML cannot fetch() this document's content
                 vscode.Uri.file(docDir)
             ]
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,6 @@
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 import * as path from 'path';
-import fileUrl = require('file-url');
 
 enum SourceType {
     SCRIPT,

--- a/static/preview.css
+++ b/static/preview.css
@@ -4,6 +4,12 @@ html, body {
     height: 100%;
 }
 
+#loading-mask {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
 div.ol-popup {
     background: #FFFFFF;
 }

--- a/static/preview.js
+++ b/static/preview.js
@@ -450,6 +450,11 @@ async function setupLayers(previewSettings) {
     return baseLayers;
 }
 
+function loadingDone() {
+    const el = document.getElementById("loading-mask");
+    el.remove();
+}
+
 function initPreviewMap(domElId, preview, previewSettings) {
     let vertexStyle = null;
     if (previewSettings.style.vertex.enabled === true) {
@@ -540,6 +545,7 @@ function initPreviewMap(domElId, preview, previewSettings) {
         declutter: previewSettings.declutterLabels
     });
     setupLayers(previewSettings).then((baseLayers) => {
+        loadingDone();
         let map = new ol.Map({
             target: 'map',
             controls: ol.control.defaults.defaults({
@@ -589,5 +595,7 @@ function initPreviewMap(domElId, preview, previewSettings) {
             if (html)
                 popup.show(evt.mapBrowserEvent.coordinate, html);
         });
+    }).catch(e => {
+        loadingDone();
     });
 }

--- a/static/preview.js
+++ b/static/preview.js
@@ -389,7 +389,7 @@ async function setupLayers(previewSettings) {
             type: 'base',
             visible: (previewSettings.defaultBaseLayer == "stadia-outdoors"),
             source: new ol.source.StadiaMaps ({
-                layer: 'stadia_outdoors',
+                layer: 'outdoors',
                 apiKey: previewSettings.apikeys.stadiamaps
             })
         }));


### PR DESCRIPTION
This PR refactors the map preview HTML generation so that the document content is not embedded with the HTML but rather, it is `fetch()`'d on init of the VSCode webview. This means we no longer have potentially huge preview HTML documents and we get better UI responsiveness (we can now show a loading status while the `fetch()` is completing for large documents).

Because the document content is no longer embedded into the generated HTML it means we no longer need our cleaning/escaping regexes. We already use DOMPurify to sanitize feature attributes for popup display, so no problems there.

Fixes #4
Fixes #14

As part of this refactoring, I've discovered that VSCode's extensions APIs will not cooperate with us on really large documents (anything above 50MB). So for such cases we will now show an error message instead of trying to proceed with a map preview that is not going to happen.

Closes #28